### PR TITLE
The solution doesn't work out the box as starting Windows 2016, Stack…

### DIFF
--- a/scripts/Create-LocalUser.ps1
+++ b/scripts/Create-LocalUser.ps1
@@ -3,7 +3,7 @@
     Create-LocalUser.ps1
 
     .DESCRIPTION
-    This script creates a new local user and adds them to the local administrators group
+    This script creates a new local user, a local group and adds the user to that group as well as the local administrators group
     
     .EXAMPLE
     .\Create-LocalUser -AdminSecParam 'arn:aws:secretsmanager:us-west-2:############:secret:example-VX5fcW' -FullName 'John Doe' -Description 'This is a local user account'
@@ -42,9 +42,18 @@ Try {
     Exit 1
 }
 
+Write-Output 'Creating local group'
+Try {
+    New-LocalGroup -Name "RDGWUsers" -Description "Users who will be authorized by default RDGW RAP" -ErrorAction Stop
+} Catch [System.Exception]{
+    Write-Output "Failed to create local Group $_"
+    Exit 1
+}
+
 Write-Output 'Adding local user to group'
 Try {
     Add-LocalGroupMember -Group 'Administrators' -Member $AdminUserName -ErrorAction Stop
+    Add-LocalGroupMember -Group "RDGWUsers" -Member $AdminUserName -ErrorAction Stop
 } Catch [System.Exception]{
     Write-Output "Failed to add local user to group $_"
     Exit 1

--- a/templates/rdgw-standalone.template
+++ b/templates/rdgw-standalone.template
@@ -391,7 +391,7 @@ Resources:
                         - UsingDefaultBucket
                         - !Ref AWS::Region
                         - !Ref QSS3BucketRegion
-                commandLine: "./Initialize-RDGW.ps1 -DomainDNSName {{DomainDNSName}} -DomainNetBiosName BUILTIN -GroupName administrators"
+                commandLine: "./Initialize-RDGW.ps1 -DomainDNSName {{DomainDNSName}} -DomainNetBiosName BUILTIN -GroupName administrators,RDGWUsers"
           - name: "completeHookAction"
             action: aws:executeAwsApi
             isEnd: true


### PR DESCRIPTION
…Admin user won't use the Administrators' group token unless UAC is disabled for all admins on the RDGW. I am proposing changes to PowerShell Scripts as well as how they are called from CFN template to have RDGWs create a local group too and assign RAP permissions through that group rather than the built-in Administrators group.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
