### PR TITLE
disable IMDSv1 to use IMDSv2 only.

### DIFF
--- a/templates/rdgw-domain.template
+++ b/templates/rdgw-domain.template
@@ -832,6 +832,9 @@ Resources:
     DeletionPolicy: Delete
     Properties:
       LaunchTemplateData:
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpTokens: required
         InstanceType: !Ref 'RDGWInstanceType'
         ImageId: !Ref 'LatestAmiId'
         SecurityGroupIds:

--- a/templates/rdgw-standalone.template
+++ b/templates/rdgw-standalone.template
@@ -600,6 +600,9 @@ Resources:
     DeletionPolicy: Delete
     Properties:
       LaunchTemplateData:
+        MetadataOptions:
+          HttpEndpoint: enabled
+          HttpTokens: required
         InstanceType: !Ref 'RDGWInstanceType'
         ImageId: !Ref 'LatestAmiId'
         SecurityGroupIds:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
n order to benefit from the improved security posture that IMDSv2 provides we are configuring EC2 instances to disable IMDSv1 and use IMDSv2 only.
Tested in the console under different scenarios of deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
